### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kirkeaton/skiz-parser/security/code-scanning/1](https://github.com/kirkeaton/skiz-parser/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this CI workflow. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
